### PR TITLE
updated class for ConcurrentUpdateSolrServer and HttpSolrServer

### DIFF
--- a/components/cfsolrlib.cfc
+++ b/components/cfsolrlib.cfc
@@ -44,10 +44,10 @@
 	
 	<cfscript>
 	// create an update server instance
-	THIS.solrUpdateServer = THIS.javaLoaderInstance.create("org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrServer").init("#THIS.solrURL#/#THIS.coreName#",THIS.queueSize,THIS.threadCount);
+	THIS.solrUpdateServer = THIS.javaLoaderInstance.create("org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient").init("#THIS.solrURL#/#THIS.coreName#",THIS.queueSize,THIS.threadCount);
 	
 	// create a query server instance
-	THIS.solrQueryServer = THIS.javaLoaderInstance.create("org.apache.solr.client.solrj.impl.HttpSolrServer").init("#THIS.solrURL#/#THIS.coreName#");
+	THIS.solrQueryServer = THIS.javaLoaderInstance.create("org.apache.solr.client.solrj.impl.HttpSolrClient").init("#THIS.solrURL#/#THIS.coreName#");
 	
 	if ( structKeyExists(arguments, "username") ) {
 		THIS.username = arguments.username;


### PR DESCRIPTION
The ConcurrentUpdateSolrServer and HttpSolrServer classes were removed in Solr6. Solr 5.5 is the last version where they were present. 

http://lucene.apache.org/solr/5_5_0/solr-solrj/org/apache/solr/client/solrj/impl/ConcurrentUpdateSolrServer.html
http://lucene.apache.org/solr/5_5_0/solr-solrj/org/apache/solr/client/solrj/impl/HttpSolrServer.html
